### PR TITLE
브라우저 예외 처리 요청

### DIFF
--- a/typescript_src/component/externalBrowser.ts
+++ b/typescript_src/component/externalBrowser.ts
@@ -73,7 +73,8 @@ export function closeOnTargetURL(
         }
     };
     const requestHandler = async (request: Request) => {
-        if (request.resourceType() === 'docmument') {
+        // 'docmument' 오타를 'document'로 수정
+        if (request.resourceType() === 'document') {
             check(page.url());
         }
     };
@@ -112,22 +113,32 @@ async function createBrowser(persist: boolean, headless: boolean) {
     // remove url bar
     // show empty browser
     const args = ['--app=data:text/html,<html></html>'];
+    
+    const chromeOptions = { headless, channel: 'chrome', args };
+    const edgeOptions = { headless, channel: 'msedge', args };
+
     if (persist) {
-        global_object.externalBrowser.browserContext =
-            await chromium.launchPersistentContext(
-                global_object.externalBrowser?.dataPath!,
-                {
-                    headless: headless,
-                    channel: 'chrome',
-                    args: args,
-                },
-            );
+        try {
+            global_object.externalBrowser.browserContext =
+                await chromium.launchPersistentContext(
+                    global_object.externalBrowser?.dataPath!,
+                    chromeOptions
+                );
+        } catch (error) {
+            console.log('Chrome not found, trying msedge instead.');
+            global_object.externalBrowser.browserContext =
+                await chromium.launchPersistentContext(
+                    global_object.externalBrowser?.dataPath!,
+                    edgeOptions
+                );
+        }
     } else {
-        global_object.externalBrowser.browser = await chromium.launch({
-            headless: headless,
-            channel: 'chrome',
-            args: args,
-        });
+        try {
+            global_object.externalBrowser.browser = await chromium.launch(chromeOptions);
+        } catch (error) {
+            console.log('Chrome not found, trying msedge instead.');
+            global_object.externalBrowser.browser = await chromium.launch(edgeOptions);
+        }
     }
 }
 


### PR DESCRIPTION
### 브라우저 예외 처리 요청
createBrowser 함수가 channel:'chrome'으로 되어 있어 오직 Chrome이 설치되어 있어야만 작동합니다,  물론 브라우저 점유율 대부분을 Chrome이 차지하긴 하나, 일부 사용자는 Chrome을 사용하지 않는 경우가 있으므로, 윈도우에 기본 설치된 Edge에 한해서 예외 처리를 부탁드리며, 장기적으로 내부 브라우저를 탑재해 주셨으면 합니다.
pull request를 요청드린 코드에는 기존의 옵션들을 chromeOptions와 edgeOptions로 각각 분리, Chrome을 먼저 시도하고, 오류를 반환하면 Edge로 시도하도록 작성했습니다.

또한 requestHandler에서 조건문 검사중 'docmument'라고 적혀있는 부분을 'document'로 수정합니다.